### PR TITLE
Feautre/auth: 로그인에 따른 헤더 상태 변경, crops api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.3",
+        "react-intersection-observer": "^9.16.0",
         "react-router-dom": "^7.6.0",
         "yup": "^1.6.1",
         "zustand": "^5.0.4"
@@ -5999,6 +6000,20 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7560,7 +7575,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
       "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.3",
+    "react-intersection-observer": "^9.16.0",
     "react-router-dom": "^7.6.0",
     "yup": "^1.6.1",
     "zustand": "^5.0.4"

--- a/src/app/crops/page.tsx
+++ b/src/app/crops/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Crop } from "@/shared/types/crop";
+
+import {
+  getCropInfo,
+  getCropInfoById,
+  updateCropInfo,
+  deleteCropInfo,
+} from "@/features/crops/api/cropApi";
+
+export default function Crops() {
+  const [crops, setCrops] = useState<Crop[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selectedCrop, setSelectedCrop] = useState<Crop | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState<Partial<Crop>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const isValid = () => {
+    if (
+      !formData.name ||
+      !formData.cultivationType ||
+      !formData.cultivationArea ||
+      !formData.cultivationAddress ||
+      !formData.plantingDate
+    ) {
+      setError("모든 필수 항목을 입력해주세요.");
+      return false;
+    }
+    setError(null);
+    return true;
+  }; // 필수 항목 체크.
+
+  useEffect(() => {
+    (async () => {
+      const data = await getCropInfo();
+      setCrops(data);
+    })();
+  }, []); // 렌더링 시 작물 정보 조회
+
+  useEffect(() => {
+    if (selectedId !== null) {
+      (async () => {
+        const detail = await getCropInfoById(selectedId);
+        setSelectedCrop(detail);
+        console.log("상세정보", detail);
+
+        setIsEditing(false);
+      })();
+    }
+  }, [selectedId]); // 작물 선택 시 상세정보 조회
+
+  const handleDelete = async () => {
+    if (selectedId !== null) {
+      await deleteCropInfo(selectedId);
+      setCrops((prev) => prev.filter((c) => c.id !== selectedId));
+      closeModal();
+    }
+  }; // 작물 삭제 로직
+
+  const handleUpdate = async () => {
+    if (!isValid()) return;
+
+    if (selectedId !== null) {
+      await updateCropInfo(selectedId, formData);
+      const updatedList = await getCropInfo();
+      setCrops(updatedList);
+      setSelectedCrop(await getCropInfoById(selectedId));
+      setIsEditing(false);
+    } // 작물 수정 로직
+  };
+  const closeModal = () => {
+    setSelectedId(null);
+    setSelectedCrop(null);
+    setIsEditing(false);
+  };
+
+  useEffect(() => {
+    if (selectedCrop) {
+      setFormData({ ...selectedCrop }); // 모든 인풋 필드에 초기값 주입
+    }
+  }, [selectedCrop]); // 상세정보 조회 후 인풋 필드에 초기값 주입
+
+  return (
+    <div className="max-w-150  p-4 border rounded-md shadow-lg">
+      <h1 className="text-2xl font-bold mb-4">수정벌 리스트</h1>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {crops.map((crop) => (
+          <li
+            key={crop.id}
+            onClick={() => setSelectedId(crop.id)}
+            className="cursor-pointer border rounded-xl p-4 shadow hover:shadow-md transition"
+          >
+            <h2 className="text-lg font-semibold">{crop.name}</h2>
+            <p className="text-sm text-gray-600">{crop.description}</p>
+          </li>
+        ))}
+      </ul>
+
+      {/* 상세 모달 */}
+      {selectedCrop && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md relative">
+            <button
+              onClick={closeModal}
+              className="absolute top-2 right-3 text-gray-500"
+            >
+              ✕
+            </button>
+            {/* 모달 내용: 수정일 경우와 아닐 경우 */}
+            {isEditing ? (
+              <>
+                <h2 className="text-xl font-semibold mb-4">작물 정보 수정</h2>
+
+                <label className="block mb-1 font-medium">
+                  이름 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, name: e.target.value })
+                  }
+                  placeholder="작물 이름"
+                  className="border w-full p-2 mb-2"
+                />
+
+                <label className="block mb-1 font-medium">품종</label>
+                <input
+                  type="text"
+                  value={formData.variety || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, variety: e.target.value })
+                  }
+                  placeholder="품종 (선택)"
+                  className="border w-full p-2 mb-2"
+                />
+
+                {/* <label className="block mb-1 font-medium">
+                  설명 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.description || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, description: e.target.value })
+                  }
+                  placeholder="작물 설명"
+                  className="border w-full p-2 mb-2"
+                /> */}
+
+                <label className="block mb-1 font-medium">
+                  재배 유형 <span className="text-red-500">*</span>
+                </label>
+                <select
+                  value={formData.cultivationType || ""}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      cultivationType: e.target.value,
+                    })
+                  }
+                  className="border w-full p-2 mb-2"
+                >
+                  <option value="">선택</option>
+                  <option value="CONTROLLED">비닐하우스</option>
+                  <option value="OPEN_FIELD">노지재배</option>
+                </select>
+
+                <label className="block mb-1 font-medium">
+                  재배 면적 (㎡) <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="number"
+                  value={formData.cultivationArea || ""}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      cultivationArea: Number(e.target.value),
+                    })
+                  }
+                  placeholder="면적"
+                  className="border w-full p-2 mb-2"
+                />
+
+                <label className="block mb-1 font-medium">
+                  재배 주소 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.cultivationAddress || ""}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      cultivationAddress: e.target.value,
+                    })
+                  }
+                  placeholder="주소"
+                  className="border w-full p-2 mb-2"
+                />
+
+                <label className="block mb-1 font-medium">
+                  식재일 <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="date"
+                  value={formData.plantingDate || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, plantingDate: e.target.value })
+                  }
+                  className="border w-full p-2 mb-2"
+                />
+
+                <button
+                  onClick={handleUpdate}
+                  className="bg-blue-500 text-white px-4 py-2 rounded mt-2 w-full"
+                >
+                  저장
+                </button>
+                {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+              </>
+            ) : (
+              <>
+                <h2 className="text-xl font-semibold mb-2">
+                  {selectedCrop.name}
+                </h2>
+                <p>품종: {selectedCrop.variety}</p>
+                <p>유형: {selectedCrop.cultivationType}</p>
+                <p>면적: {selectedCrop.cultivationArea} ㎡</p>
+                <p>주소: {selectedCrop.cultivationAddress}</p>
+                <p>식재일: {selectedCrop.plantingDate}</p>
+
+                <div className="flex gap-2 mt-4">
+                  <button
+                    onClick={() => setIsEditing(true)}
+                    className="bg-yellow-400 px-4 py-2 rounded"
+                  >
+                    수정
+                  </button>
+                  <button
+                    onClick={handleDelete}
+                    className="bg-red-500 text-white px-4 py-2 rounded"
+                  >
+                    삭제
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,7 +8,7 @@ import {
 
 export default function myPage() {
   return (
-    <div className=" max-w-[75%] flex flex-col gap-10 mx-auto">
+    <div className=" max-w-[75%] flex flex-col gap-10 mx-auto mb-20">
       <div className="flex flex-row justify-between gap-7">
         <BeehiveMap />
         <MyProfile />

--- a/src/features/Logout/ui/Logout.tsx
+++ b/src/features/Logout/ui/Logout.tsx
@@ -14,6 +14,7 @@ export default function AuthButton() {
     } else {
       router.push("/signIn");
     }
+    console.log(document.cookie);
   };
 
   return (

--- a/src/features/Register/cropInfo/api/index.ts
+++ b/src/features/Register/cropInfo/api/index.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { CropFormData } from "@/shared/types/crop";
+import api from "@/shared/auth/lib";
+
+// 작물 정보 등록
+export const PostCropInfo = () => {
+  const postCropInfo = useCallback(async (data: CropFormData) => {
+    try {
+      const response = await api.post("profile/crops", {
+        name: data.crop,
+        variety: data.variety,
+        cultivationType:
+          data.method === "비닐하우스" ? "CONTROLLED" : "OPEN_FIELD",
+        cultivationAddress: data.location,
+        cultivationArea: Number(data.area),
+        plantingDate: data.plantingDate,
+      });
+      console.log("작물 정보 등록 성공:", response.data);
+      return response.data;
+    } catch (error) {
+      console.error("작물 정보 등록 오류:", error);
+      throw error;
+    }
+  }, []);
+
+  return { postCropInfo };
+};
+

--- a/src/features/Register/cropInfo/model/useCropInfo.ts
+++ b/src/features/Register/cropInfo/model/useCropInfo.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { CropFormData } from "@/shared/types/crop";
+import { PostCropInfo } from "../api";
+export function useCropInfo() {
+  const { postCropInfo } = PostCropInfo();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitCropInfo = async (formData: CropFormData) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await postCropInfo(formData);
+      setError("작물이 등록되었습니다.");
+      console.log("작물 등록 성공:", formData);
+      return true;
+    } catch (error) {
+      setError("작물 등록에 실패했습니다.");
+      console.error("작물 등록 오류:", error);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    submitCropInfo,
+    loading,
+    error,
+  };
+}

--- a/src/features/Register/cropInfo/ui/cropInfo.tsx
+++ b/src/features/Register/cropInfo/ui/cropInfo.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { useCropInfo } from "../model/useCropInfo";
 
 export default function CropInfo() {
+  const { submitCropInfo, loading, error } = useCropInfo();
   const [form, setForm] = useState({
     crop: "",
     variety: "",
@@ -19,8 +21,25 @@ export default function CropInfo() {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const isSuccess = await submitCropInfo(form);
+    if (isSuccess) {
+      setForm({
+        crop: "",
+        variety: "",
+        method: "",
+        location: "",
+        area: "",
+        plantingDate: "",
+      });
+    }
+  };
   return (
-    <form className="space-y-6 max-w-[1000px] w-full  text-black flex flex-col justify-center rounded-2xl items-start custom-box-shadow">
+    <form
+      className="space-y-6 max-w-[1000px] w-full  text-black flex flex-col justify-center rounded-2xl items-start custom-box-shadow"
+      onSubmit={handleSubmit}
+    >
       {/* 제목 및 설명 */}
       <div className="bg-[#EEF2FF] w-full h-[60px] px-4 py-3 rounded-t-2xl">
         <div className="font-semibold text-[16px]">
@@ -144,9 +163,11 @@ export default function CropInfo() {
           <button
             type="submit"
             className="bg-blue-500 text-white px-15 py-2 rounded my-5 "
+            disabled={loading}
           >
-            재배 작물 추가
+            {loading ? "등록 중..." : "재배 작물 추가"}
           </button>
+          {error && <div className="text-red-500 text-sm pb-5">{error}</div>}
         </div>
       </div>
     </form>

--- a/src/features/crops/api/cropApi.ts
+++ b/src/features/crops/api/cropApi.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import api from "@/shared/auth/lib";
+import { Crop } from "@/shared/types/crop";
+
+// 작물 전체 정보 조회
+export const getCropInfo = async (): Promise<Crop[]> => {
+  try {
+    const res = await api.get("profile/crops");
+    console.log("작물 정보 조회 성공:", res.data);
+    return res.data.data;
+  } catch (e) {
+    console.error("작물 정보 조회 오류:", e);
+    return [];
+  }
+};
+
+// 작물 상세 정보 조회
+export const getCropInfoById = async (id: number): Promise<Crop | null> => {
+  try {
+    const res = await api.get(`profile/crops/${id}`);
+    return res.data.data;
+  } catch (e) {
+    console.error("상세 조회 오류:", e);
+    return null;
+  }
+};
+// 작물 정보 수정
+export const updateCropInfo = async (id: number, data: Partial<Crop>) => {
+  try {
+    const res = await api.put(`profile/crops/${id}`, data);
+    return res.data;
+  } catch (e) {
+    console.error("수정 오류:", id, data, e);
+  }
+};
+// 작물 정보 삭제
+export const deleteCropInfo = async (id: number) => {
+  try {
+    await api.delete(`profile/crops/${id}`);
+  } catch (e) {
+    console.error("삭제 오류:", e);
+  }
+};

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -1,3 +1,29 @@
 export default function MySaleList() {
-  return <div>ss</div>;
+  return (
+    <div className="custom-box2 w-full min-h-fit h-[280px]  flex flex-col justify-center items-center pb-10">
+      <div className="custom-box2-title mb-4">내가 등록한 상품 목록</div>
+      <div className="flex flex-row justify-between items-center w-full h-full px-10 gap-4">
+        {[1, 2, 3, 4].map((item) => (
+          <div
+            key={item}
+            className="w-1/4 max-w-[320px] h-[280px] rounded-md border border-gray-300 flex flex-col"
+          >
+            {/* 위쪽 회색 박스 */}
+            <div className="bg-[#E5E7EB] h-1/2 w-full rounded-t-md" />
+
+            {/* 아래쪽 흰 배경 박스 */}
+            <div className="h-1/2 w-full bg-white p-4 rounded-b-md flex flex-col justify-between">
+              <div className="flex flex-col">
+                <div className="text-sm font-semibold mb-1">상품 제목</div>
+                <div className="text-[#615FFF] text-sm">150,000원</div>
+              </div>
+              <button className="mt-4 text-[#2B7FFF] border border-[#2B7FFF] px-3 py-1 rounded-md hover:bg-[#2B7FFF] hover:text-white transition self-start mb-10">
+                수정
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/src/shared/auth/api.ts
+++ b/src/shared/auth/api.ts
@@ -28,7 +28,7 @@ export async function signOut() {
   const response = await api.post("/auth/sign-out");
   // 클라이언트 상태 초기화
   localStorage.removeItem("accessToken");
-  document.cookie = "refreshToken=; path=/; max-age=0;";
+  // document.cookie = "refreshToken=; path=/; max-age=0;";
   await useUserStore.getState().logout();
   return response.data;
 }

--- a/src/shared/types/crop.ts
+++ b/src/shared/types/crop.ts
@@ -1,0 +1,19 @@
+export interface CropFormData {
+  crop: string;
+  variety: string;
+  method: string;
+  location: string;
+  area: string;
+  plantingDate: string;
+}
+
+export interface Crop {
+  id: number;
+  name: string;
+  description: string;
+  variety?: string;
+  cultivationType?: string;
+  cultivationAddress?: string;
+  cultivationArea?: number;
+  plantingDate?: string;
+}

--- a/src/widgets/header/ui/header.tsx
+++ b/src/widgets/header/ui/header.tsx
@@ -2,9 +2,11 @@
 
 import { useRouter } from "next/navigation";
 import { Logout } from "@/features";
+import { useUserStore } from "@/shared/auth/useUserStore";
 
 export default function Header() {
   const router = useRouter();
+  const { userName } = useUserStore();
 
   return (
     <div className="w-full h-20 px-10 flex flex-row justify-around items-center bg-white text-black text-xl border-b border-gray-300 mb-20">
@@ -24,9 +26,14 @@ export default function Header() {
         <div className="cursor-pointer" onClick={() => router.push("/guide")}>
           수정벌 가이드
         </div>
-        <div className="cursor-pointer" onClick={() => router.push("/mypage")}>
-          마이페이지
-        </div>
+        {userName && (
+          <div
+            className="cursor-pointer"
+            onClick={() => router.push("/mypage")}
+          >
+            마이페이지
+          </div>
+        )}
         <Logout />
       </div>
     </div>

--- a/src/widgets/home/quickProfile/ui/quickProfile.tsx
+++ b/src/widgets/home/quickProfile/ui/quickProfile.tsx
@@ -1,8 +1,10 @@
 "use client";
+import { useUserStore } from "@/shared/auth/useUserStore";
 import Image from "next/image";
 
 export default function QuickProfile() {
-  const realName = localStorage.getItem("realName");
+  const { realName } = useUserStore();
+
   return (
     <div className="custom-box  basis-[25%] h-60 flex flex-col  justify-around ">
       <div className=" flex flex-row justify-start items-end ml-5">


### PR DESCRIPTION
1. /mypage 페이지에 판매물품 섹션 퍼블리싱 추가

2. /crops 페이지 추가 및 작물 정보 조회/수정/삭제 로직 구현 (figma는 아직..)

3. 작물 등록 기능을 위한 API 연동 로직 (postCropInfo) 추가

4. 로그인 상태에 따른 사이드바  ui 변경