### PR TITLE
fix:판매목록 레이아웃 정상화

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,9 +115,9 @@ body {
 }
 
 .custom-button:hover {
-  background-color: #7c86ff;
+  background-color: #2b7fff;
   color: #ffffff;
-  border-color: #7c86ff;
+  border-color: #2b7fff;
 }
 
 /*

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -7,11 +7,9 @@ import {
 
 export default function MyPage() {
   return (
-    <div className="lg:w-[65%] flex flex-col gap-8 mx-auto pt-30 pb-10">
-      <div className="flex flex-row gap-6 w-full">
-        <MySaleList />
-        <MyProfile />
-      </div>
+    <div className="w-[90%] xl:w-[65%] flex flex-col gap-8 mx-auto pt-30 pb-10">
+      <MyProfile />
+      <MySaleList />
       <StoreRecommendBee />
       <DiagnosisHistory />
     </div>

--- a/src/features/mypage/myProfile/ui/myBusinessList.tsx
+++ b/src/features/mypage/myProfile/ui/myBusinessList.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useBusinessStore } from "@/shared/business/model";
-import { BusinessDetailPopup } from "./myBusinessDetailpopup"
+import { BusinessDetailPopup } from "./myBusinessDetailpopup";
 import { useState } from "react";
 
 export function BusinessList() {

--- a/src/features/mypage/myProfile/ui/myProfile.tsx
+++ b/src/features/mypage/myProfile/ui/myProfile.tsx
@@ -31,74 +31,78 @@ export default function MyProfile() {
   }
 
   return (
-    <div className="custom-box h-full text-xs flex flex-col justify-between items-start p-4 gap-4 w-[30%]">
-      {/* 상단 컨텐츠 */}
-      <div className="flex flex-col gap-4 w-full">
-        {/* 사용자 정보 헤더 */}
-        <div className="w-full flex flex-row justify-between items-center">
-          <div>
-            <span className="font-bold text-xl">{realName || "사용자"}</span>님
-            반갑습니다
-          </div>
-          <div>
-            <a href="" className="underline hover:text-black">
-              프로필 수정
-            </a>
-          </div>
+    <div className="custom-box text-xs">
+      {/* 사용자 정보 헤더 */}
+      <div className="flex flex-row justify-between items-center ">
+        <div>
+          <span className="font-bold text-xl">{realName || "사용자"}</span>님
+          반갑습니다
         </div>
+        <div>
+          <a href="" className="underline hover:text-black">
+            프로필 수정
+          </a>
+        </div>
+      </div>{" "}
+      <div className="w-full h-px bg-gray-200"></div>
+      <div className=" flex flex-row justify-between items-start p-2 gap-4 ">
+        {/* 상단 컨텐츠 */}
 
-        {/* 컨텐츠 영역 */}
-        <div className="flex flex-col justify-start items-center gap-1 w-full">
-          {/* 나의 업체 정보 */}
-          <div className="flex flex-col gap-2 w-full">
-            <div>나의 업체 정보</div>
-            <div className="flex flex-row gap-1 overflow-x-auto scrollbar-hide hover:scrollbar-show group">
-              <BusinessList />
+        <div className="flex flex-col gap-4 w-[70%]">
+          {/* 컨텐츠 영역 */}
+          <div className="flex flex-col justify-start items-start gap-1 ">
+            {/* 나의 업체 정보 */}
+            <div className="flex flex-col gap-2 w-full pr-4">
+              <div>나의 업체 정보</div>
+              <div className="flex flex-row gap-1 overflow-x-auto scrollbar-hide hover:scrollbar-show group">
+                <BusinessList />
+              </div>
             </div>
-          </div>
 
-          {/* 나의 농지 정보 - 동적 데이터 */}
-          <div className="flex flex-col gap-2 w-full">
-            <div>나의 농지 정보</div>
-            <div className="flex flex-row gap-1 overflow-x-auto scrollbar-thin">
-              {cropAddresses.length > 0 ? (
-                cropAddresses.map((address, index) => (
-                  <div key={index} className="custom-button whitespace-nowrap">
-                    {address}
+            {/* 나의 농지 정보 - 동적 데이터 */}
+            <div className="flex flex-col gap-2 w-full">
+              <div>나의 농지 정보</div>
+              <div className="flex flex-row gap-1 overflow-x-auto scrollbar-thin">
+                {cropAddresses.length > 0 ? (
+                  cropAddresses.map((address, index) => (
+                    <div
+                      key={index}
+                      className="custom-button whitespace-nowrap"
+                    >
+                      {address}
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-gray-500 text-sm py-2">
+                    등록된 농지 정보가 없습니다.
                   </div>
-                ))
-              ) : (
-                <div className="text-gray-500 text-sm py-2">
-                  등록된 농지 정보가 없습니다.
-                </div>
-              )}
+                )}
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* 하단 액션 버튼 영역 */}
-      <div className="w-full flex flex-col gap-3 mt-auto">
-        <div className="w-full h-px bg-gray-200"></div>
-        <div className="flex flex-col gap-2">
-          <button
-            onClick={() => (window.location.href = "/products")}
-            className="w-full bg-[#2B7FFF] text-white py-3 px-4 rounded-lg hover:bg-[#1E6FE6] transition-colors font-medium text-sm"
-          >
-            + 새 상품 등록하기
-          </button>
-          <button
-            onClick={() => (window.location.href = "/myprofile")}
-            className="w-full border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors text-sm"
-          >
-            업체 등록하기
-          </button>
-          <button
-            onClick={() => (window.location.href = "/cropInfo")}
-            className="w-full border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors text-sm"
-          >
-            작물정보 등록하기
-          </button>
+        <div className="w-full flex flex-col gap-3 mt-auto">
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={() => (window.location.href = "/products")}
+              className="w-full bg-[#2B7FFF] text-white py-3 px-4 rounded-lg hover:bg-[#1E6FE6] transition-colors font-medium text-sm"
+            >
+              + 새 상품 등록하기
+            </button>
+            <button
+              onClick={() => (window.location.href = "/myprofile")}
+              className="w-full border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors text-sm"
+            >
+              업체 등록하기
+            </button>
+            <button
+              onClick={() => (window.location.href = "/cropInfo")}
+              className="w-full border border-gray-300 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors text-sm"
+            >
+              작물정보 등록하기
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -17,7 +17,7 @@ export default function MySaleList() {
   // 로딩 상태
   if (isLoading) {
     return (
-      <div className="custom-box2 shadow-lg w-full h-full flex flex-col justify-center items-center pb-10">
+      <div className="custom-box2 w-full h-full flex flex-col justify-center items-center pb-10">
         <div className="custom-box2-title mb-4">내가 등록한 상품 목록</div>
         <div className="flex items-center justify-center flex-1">
           <div className="flex items-center gap-2">
@@ -32,7 +32,7 @@ export default function MySaleList() {
   // 에러 상태
   if (error) {
     return (
-      <div className="custom-box2 shadow-lg w-full h-full flex flex-col justify-center items-center pb-10">
+      <div className="custom-box2 w-full h-full flex flex-col justify-center items-center pb-10">
         <div className="custom-box2-title mb-4">내가 등록한 상품 목록</div>
         <div className="flex items-center justify-center flex-1">
           <div className="text-center">
@@ -52,7 +52,7 @@ export default function MySaleList() {
   // 상품이 없는 경우
   if (!isLoading && myProducts.length === 0) {
     return (
-      <div className="custom-box2 w-full h-full flex flex-col justify-center shadow-lg items-center">
+      <div className="custom-box2 w-full h-full flex flex-col justify-center items-center">
         <div className="custom-box2-title mb-4">내가 등록한 상품 목록</div>
         <div className="flex items-center justify-center flex-1">
           <div className="text-center">
@@ -65,15 +65,15 @@ export default function MySaleList() {
   }
 
   return (
-    <div className="custom-box2 shadow-lg flex flex-col w-[70%] overflow-auto">
+    <div className="custom-box2 flex flex-col">
       <div className="custom-box2-title mb-4">
-        <span className="custom-box2-icon">🛒</span>내가 등록한 상품 목록
+        <span className="custom-box2-icon">🛒</span> 내가 등록한 상품 목록
       </div>
 
       {/* 슬라이드 컨테이너 */}
       <div className="relative w-full px-10 py-4">
         {/* 상품 슬라이드 */}
-        <div className="flex flex-row justify-between items-center w-full h-full gap-2">
+        <div className="flex flex-row justify-between items-center w-full gap-2">
           {visibleProducts.map((product, index) => (
             <ProductCard
               key={product.id}
@@ -85,7 +85,7 @@ export default function MySaleList() {
         </div>
 
         {/* 좌우 네비게이션 버튼 */}
-        {myProducts.length > 2 && (
+        {myProducts.length > 4 && (
           <>
             <NavigationButton
               direction="prev"

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -32,9 +32,9 @@ export const ProductCard = memo<ProductCardProps>(
     }, []);
 
     return (
-      <div className="w-[235px] h-[90%] rounded-md border border-gray-300 flex flex-col hover:shadow-md transition-all duration-300 group">
+      <div className="w-[215px] h-[180px] rounded-md border border-gray-300 flex flex-col hover:shadow-md transition-all duration-300 group">
         {/* 상품 이미지 */}
-        <div className="h-2/3 rounded-t-md overflow-hidden relative">
+        <div className="h-1/2 rounded-t-md overflow-hidden relative">
           {product.imageUrls && product.imageUrls.length > 0 && !imageError ? (
             <>
               {/* 로딩 스켈레톤 */}


### PR DESCRIPTION
판매목록 레이아웃 원상복귀
페이지 너비가 65%인데, 컴포넌트 두개를 이 안에 맞추자니 복잡해서 
마이프로필을 위로 뺐습니다. 

<img width="961" height="710" alt="image" src="https://github.com/user-attachments/assets/1dd74537-641c-449d-bb3d-8c11f54c8a35" />
