### PR TITLE
[perf, refactor] Mypage 성능 개선 및 코드 베이스 정리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    formats: ['image/webp', 'image/avif'],
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-    imageSizes: [16, 32, 48, 64, 96, 128, 256, 280, 320, 384],
-    minimumCacheTTL: 31536000,
-    dangerouslyAllowSVG: false,
-    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
         protocol: 'https',
@@ -20,7 +14,6 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
-      // 개발용 (필요시)
       {
         protocol: 'https',
         hostname: 'cataas.com',
@@ -28,7 +21,31 @@ const nextConfig = {
         pathname: '/**',
       },
     ],
+    // 이미지 최적화 설정
+    formats: ['image/webp', 'image/avif'],
+    deviceSizes: [320, 420, 768, 1024, 1200],
+    imageSizes: [16, 32, 48, 64, 96, 128, 160, 180, 200, 280],
+    // 최적화된 이미지 캐싱
+    minimumCacheTTL: 31536000, // 1년
   },
+  // 컴파일러 최적화
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production',
+  },
+  // 실험적 기능 활성화
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+    turbo: {
+      rules: {
+        '*.svg': {
+          loaders: ['@svgr/webpack'],
+          as: '*.js',
+        },
+      },
+    },
+  },
+  // 정적 최적화
+  output: 'standalone',
 }
 
 module.exports = nextConfig

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig = {
     formats: ['image/webp', 'image/avif'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 280, 320, 384],
+    minimumCacheTTL: 31536000,
+    dangerouslyAllowSVG: false,
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
         protocol: 'https',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-query-devtools": "^5.80.7",
     "axios": "^1.9.0",
-    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.513.0",
     "next": "15.3.1",
@@ -22,9 +21,6 @@
     "react-daum-postcode": "^3.2.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.3",
-    "react-intersection-observer": "^9.16.0",
-    "react-router-dom": "^7.6.0",
-    "root": "git+https://github.com/tanstack/react-query.git",
     "tailwind-merge": "^3.3.1",
     "yup": "^1.6.1",
     "zustand": "^5.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       axios:
         specifier: ^1.9.0
         version: 1.10.0
-      class-variance-authority:
-        specifier: ^0.7.1
-        version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -47,15 +44,6 @@ importers:
       react-hook-form:
         specifier: ^7.56.3
         version: 7.58.0(react@19.1.0)
-      react-intersection-observer:
-        specifier: ^9.16.0
-        version: 9.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react-router-dom:
-        specifier: ^7.6.0
-        version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      root:
-        specifier: git+https://github.com/tanstack/react-query.git
-        version: git+https://github.com/tanstack/react-query.git#33d008bbb39f749588ab591d41fefa53f4e18c99
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -1208,9 +1196,6 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  class-variance-authority@0.7.1:
-    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1241,10 +1226,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2147,15 +2128,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
-  react-intersection-observer@9.16.0:
-    resolution: {integrity: sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2177,23 +2149,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  react-router-dom@7.6.2:
-    resolution: {integrity: sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.6.2:
-    resolution: {integrity: sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
         optional: true
 
   react-style-singleton@2.2.3:
@@ -2242,10 +2197,6 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  root@git+https://github.com/tanstack/react-query.git#33d008bbb39f749588ab591d41fefa53f4e18c99:
-    resolution: {commit: 33d008bbb39f749588ab591d41fefa53f4e18c99, repo: https://github.com/tanstack/react-query.git, type: git}
-    version: 0.0.0
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2282,9 +2233,6 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3689,10 +3637,6 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  class-variance-authority@0.7.1:
-    dependencies:
-      clsx: 2.1.1
-
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
@@ -3722,8 +3666,6 @@ snapshots:
   commander@2.20.3: {}
 
   concat-map@0.0.1: {}
-
-  cookie@1.0.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4732,12 +4674,6 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  react-intersection-observer@9.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-    optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
-
   react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.1.8)(react@19.1.0):
@@ -4758,20 +4694,6 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.1.8)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.8
-
-  react-router-dom@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-
-  react-router@7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      cookie: 1.0.2
-      react: 19.1.0
-      set-cookie-parser: 2.7.1
-    optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
 
   react-style-singleton@2.2.3(@types/react@19.1.8)(react@19.1.0):
     dependencies:
@@ -4823,8 +4745,6 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  root@git+https://github.com/tanstack/react-query.git#33d008bbb39f749588ab591d41fefa53f4e18c99: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4866,8 +4786,6 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
-
-  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,35 +42,8 @@
     contain: layout style;
   }
 
-  /* 스켈레톤 애니메이션 최적화 */
-  .skeleton-pulse {
-    animation: skeleton-loading 1.5s ease-in-out infinite alternate;
-    background: linear-gradient(90deg, #f0f0f0 0%, #e0e0e0 50%, #f0f0f0 100%);
-    background-size: 200% 100%;
-  }
 
-  @keyframes skeleton-loading {
-    0% {
-      background-position: 200% 0;
-    }
-    100% {
-      background-position: -200% 0;
-    }
-  }
 
-  /* GPU 가속 최적화 */
-  .gpu-accelerated {
-    will-change: transform;
-    transform: translateZ(0);
-    backface-visibility: hidden;
-    perspective: 1000px;
-  }
-
-  /* 컨텐츠 시프트 방지 */
-  .content-visibility-auto {
-    content-visibility: auto;
-    contain-intrinsic-size: 0 200px;
-  }
 }
 
 :root {
@@ -320,12 +293,6 @@ body {
     @apply w-1/4 h-10 bg-blue-500 text-white rounded-md mt-5 flex items-center justify-center cursor-pointer;
   }
 
-  /* Layout Shift 방지를 위한 컴포넌트 스타일 */
-  .fixed-aspect-card {
-    @apply relative w-full;
-    aspect-ratio: 280 / 320; /* 카드 비율 고정 */
-    min-height: var(--card-min-height);
-  }
 
   .fixed-image-container {
     @apply relative w-full overflow-hidden rounded-t-lg bg-gray-100;
@@ -339,13 +306,6 @@ body {
     flex-shrink: 0;
   }
 
-  /* 스켈레톤 카드 최적화 */
-  .skeleton-card {
-    @apply bg-white rounded-2xl border border-transparent;
-    min-width: 280px;
-    height: 180px;
-    contain: layout style;
-  }
 
   /* 리스트 컨테이너 최적화 */
   .list-container {
@@ -354,13 +314,6 @@ body {
     contain: layout style;
   }
 
-  /* 그리드 컨테이너 최적화 */
-  .responsive-grid {
-    @apply grid gap-4 justify-items-center;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    min-height: 250px;
-    contain: layout;
-  }
 
   /* 텍스트 잘림 방지 */
   .text-ellipsis-2-lines {
@@ -390,13 +343,6 @@ body {
   font-weight: bold;
 }
 
-.inner-shadow-fake {
-  background: white;
-  color: transparent;
-  text-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
-  -webkit-background-clip: text;
-  background-clip: text;
-}
 
 /* 챗봇 열기 모션 */
 @keyframes fadeInUp {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,8 +66,6 @@ export default function RootLayout({
         <link rel="preconnect" href="https://mts.daumcdn.net" />
         <link rel="dns-prefetch" href="https://mts.daumcdn.net" />
         <link rel="preconnect" href="https://api.webee.sbs" />
-        <link rel="preconnect" href="https://d96w70pr33mqi.cloudfront.net" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://d96w70pr33mqi.cloudfront.net" />
       </head>
       <body
         className="antialiased" // 폰트 로딩 완료 후 제거

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,6 +66,7 @@ export default function RootLayout({
         <link rel="preconnect" href="https://mts.daumcdn.net" />
         <link rel="dns-prefetch" href="https://mts.daumcdn.net" />
         <link rel="preconnect" href="https://api.webee.sbs" />
+        <link rel="preconnect" href="https://d96w70pr33mqi.cloudfront.net" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://d96w70pr33mqi.cloudfront.net" />
       </head>
       <body

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { Weather2 } from "@/features";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { useEffect, useState } from "react";
-import Head from "next/head";
 
 export default function Home() {
   const router = useRouter();
@@ -29,11 +28,6 @@ export default function Home() {
   };
 
   return (
-    <>
-      <Head>
-        <link rel="canonical" href="https://webee-ten.vercel.app/" />
-        <meta name="description" content="수정벌과 관련된 모든 정보! AI 질병진단, 맞춤 수정벌 추천, 거래 연결, 농약 정보까지 농업인의 든든한 파트너 webee와 함께하세요." />
-      </Head>
       <div className="relative">
       {/* 떠다니는 벌 효과 */}
       {showBee && (
@@ -190,6 +184,5 @@ export default function Home() {
         </article>
       </section>
     </div>
-    </>
   );
 }

--- a/src/app/signIn/model/useSignIn.ts
+++ b/src/app/signIn/model/useSignIn.ts
@@ -33,6 +33,7 @@ export function useSignInForm() {
       await signIn(data);
       router.push("/ ");
     } catch (error) {
+      console.error(error);
       setError("password", {
         message: "로그인에 실패했습니다.",
       });

--- a/src/app/signIn/model/useSignIn.ts
+++ b/src/app/signIn/model/useSignIn.ts
@@ -36,7 +36,6 @@ export function useSignInForm() {
       setError("password", {
         message: "로그인에 실패했습니다.",
       });
-      console.log("로그인 실패:", error);
     }
   };
 

--- a/src/app/signUp/model/useSignUp.ts
+++ b/src/app/signUp/model/useSignUp.ts
@@ -56,7 +56,6 @@ export function useSignUpForm() {
       const axiosError = error as AxiosError<{ message: string }>;
       const errorMessage =
         axiosError.response?.data?.message ?? "회원가입에 실패했습니다.";
-      console.log(axiosError);
       setSignUpError(errorMessage);
       setLoading(false);
     }

--- a/src/features/Logout/ui/Logout.tsx
+++ b/src/features/Logout/ui/Logout.tsx
@@ -14,7 +14,6 @@ export default function AuthButton() {
     } else {
       router.push("/signIn");
     }
-    console.log(document.cookie);
   };
 
   return (

--- a/src/features/Register/businessProfile/ui/businessProfile.tsx
+++ b/src/features/Register/businessProfile/ui/businessProfile.tsx
@@ -37,7 +37,6 @@ export default function BusinessProfileForm() {
 
     try {
       const res = await postBusinessProfile(payload);
-      console.log("성공:", res);
       alert("등록 완료되었습니다!");
     } catch (error) {
       console.error(error);
@@ -201,7 +200,6 @@ export default function BusinessProfileForm() {
                 <PostcodeModal
                   setIsOpen={setIsOpen}
                   onComplete={(address) => {
-                    console.log("선택된 주소:", address);
                     setSelectedAddress(address);
                   }}
                 />

--- a/src/features/Register/businessProfile/ui/businessProfile.tsx
+++ b/src/features/Register/businessProfile/ui/businessProfile.tsx
@@ -36,7 +36,7 @@ export default function BusinessProfileForm() {
     };
 
     try {
-      const res = await postBusinessProfile(payload);
+      await postBusinessProfile(payload);
       alert("등록 완료되었습니다!");
     } catch (error) {
       console.error(error);

--- a/src/features/Register/cropInfo/api/index.ts
+++ b/src/features/Register/cropInfo/api/index.ts
@@ -14,7 +14,6 @@ export const PostCropInfo = () => {
         cultivationArea: Number(data.area),
         plantingDate: data.plantingDate,
       });
-      console.log("작물 정보 등록 성공:", response.data);
       return response.data;
     } catch (error) {
       console.error("작물 정보 등록 오류:", error);

--- a/src/features/Register/cropInfo/model/useCropInfo.ts
+++ b/src/features/Register/cropInfo/model/useCropInfo.ts
@@ -14,7 +14,6 @@ export function useCropInfo() {
       setError(
         "작물이 등록되었습니다. 수정벌 추천 > 작물 정보 가져오기에서 저장 내용을 확인하실 수 있습니다. "
       );
-      console.log("작물 등록 성공:", formData);
       return true;
     } catch (error) {
       setError("작물 등록에 실패했습니다.");

--- a/src/features/crops/api/cropApi.ts
+++ b/src/features/crops/api/cropApi.ts
@@ -14,7 +14,7 @@ export const getCropInfo = async (): Promise<Crop[]> => {
   }
 };
 
-// 작물 상세 정보 조회 - 사용 안 함
+// 작물 상세 정보 조회
 export const getCropInfoById = async (id: number): Promise<Crop | null> => {
   try {
     const res = await api.get(`/profile/crops/${id}`);

--- a/src/features/mypage/diagnosisHistory/ui/diagnosisHistory.tsx
+++ b/src/features/mypage/diagnosisHistory/ui/diagnosisHistory.tsx
@@ -174,7 +174,6 @@ export default function DiagnosisHistory() {
       const response = await api.get(`/bee/diagnosis/${beeDiagnosisId}`);
       setDetailContent(response.data.data);
     } catch (error) {
-      console.log("질병진단결과 세부내용 조회 오류", error);
       setDetailModal(false);
     }
   };

--- a/src/features/mypage/diagnosisHistory/ui/diagnosisHistory.tsx
+++ b/src/features/mypage/diagnosisHistory/ui/diagnosisHistory.tsx
@@ -174,6 +174,7 @@ export default function DiagnosisHistory() {
       const response = await api.get(`/bee/diagnosis/${beeDiagnosisId}`);
       setDetailContent(response.data.data);
     } catch (error) {
+      console.error(error);
       setDetailModal(false);
     }
   };

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect, useMemo } from "react";
 import { useMySaleList } from "../model/model";
 import { ProductCard } from "./productCards";
 import { NavigationButton } from "./navButton";
@@ -93,8 +93,10 @@ export default function MySaleList() {
     return new Intl.NumberFormat("ko-KR").format(price) + "원";
   }, []);
 
-  // 반응형 그리드 클래스
-  const gridClasses = "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
+  // 반응형 그리드 클래스 - 메모이제이션
+  const gridClasses = useMemo(() => 
+    "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3", 
+  []);
 
   return (
     <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden isolate transform-gpu">

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -5,26 +5,23 @@ import { useMySaleList } from "../model/model";
 import { ProductCard } from "./productCards";
 import { NavigationButton } from "./navButton";
 
-// 스켈레톤 카드 컴포넌트
+// 스켈레톤 카드 컴포넌트 - 단순화
 const SkeletonProductCard: React.FC = () => (
   <div className="w-full max-w-[280px] flex justify-center isolate transform-gpu">
-    <div className="w-full h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm animate-pulse">
+    <div className="w-full h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm">
       {/* 이미지 영역 */}
-      <div className="w-full h-[200px] sm:h-[180px] lg:h-[160px] bg-gray-200 rounded-t-lg"></div>
+      <div className="w-full h-[200px] sm:h-[180px] lg:h-[160px] bg-gray-200 rounded-t-lg animate-pulse"></div>
       
       {/* 컨텐츠 영역 */}
       <div className="p-3 sm:p-4 h-[120px] flex flex-col justify-between">
         <div className="space-y-2">
-          {/* 상품명 */}
-          <div className="h-5 bg-gray-200 rounded w-3/4"></div>
-          {/* 가격 */}
-          <div className="h-6 bg-gray-200 rounded w-1/2"></div>
+          <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse"></div>
+          <div className="h-6 bg-gray-200 rounded w-1/2 animate-pulse"></div>
         </div>
         
-        {/* 하단 정보 */}
         <div className="flex items-center justify-between">
-          <div className="h-4 bg-gray-200 rounded-full w-16"></div>
-          <div className="h-4 bg-gray-200 rounded w-12"></div>
+          <div className="h-4 bg-gray-200 rounded-full w-16 animate-pulse"></div>
+          <div className="h-4 bg-gray-200 rounded w-12 animate-pulse"></div>
         </div>
       </div>
     </div>
@@ -58,27 +55,36 @@ const ErrorState: React.FC<{ error: string; onRetry: () => void }> = ({ error, o
 
 export default function MySaleList() {
   const { myProducts, visibleProducts, slideInfo, isLoading, error, actions } = useMySaleList();
-  const [itemsToShow, setItemsToShow] = useState(1); // 기본값을 1로 변경
+  const [itemsToShow, setItemsToShow] = useState(1);
 
-  // 개선된 반응형 설정: sm(1개), md(2개), lg+(3개)
+  // 반응형 설정 - 최적화
   useEffect(() => {
-    const handleResize = () => {
+    const updateItemsToShow = () => {
       const width = window.innerWidth;
       
-      if (width >= 1024) {        // lg: 1024px 이상 -> 3개
+      if (width >= 1024) {
         setItemsToShow(3);
-      } else if (width >= 768) {  // md: 768px 이상 -> 2개  
+      } else if (width >= 768) {
         setItemsToShow(2);
-      } else {                    // sm: 768px 미만 -> 1개
+      } else {
         setItemsToShow(1);
       }
     };
 
-    handleResize();
-    window.addEventListener('resize', handleResize);
+    updateItemsToShow();
+    
+    // 디바운스된 리사이즈 핸들러
+    let timeoutId: NodeJS.Timeout;
+    const debouncedResize = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(updateItemsToShow, 150);
+    };
+
+    window.addEventListener('resize', debouncedResize, { passive: true });
     
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', debouncedResize);
+      clearTimeout(timeoutId);
     };
   }, []);
 
@@ -87,94 +93,84 @@ export default function MySaleList() {
     return new Intl.NumberFormat("ko-KR").format(price) + "원";
   }, []);
 
-  // 반응형 그리드 클래스 생성
-  const getGridClasses = () => {
-    return "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
-  };
+  // 반응형 그리드 클래스
+  const gridClasses = "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
 
   return (
-    <>
-      
-      <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden isolate transform-gpu">
-        {/* 헤더 */}
-        <div className="custom-box2-title mb-4 flex-shrink-0">
-          <span className="custom-box2-icon">🛒</span> 내 상품 목록
-        </div>
+    <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden isolate transform-gpu">
+      {/* 헤더 */}
+      <div className="custom-box2-title mb-4 flex-shrink-0">
+        <span className="custom-box2-icon">🛒</span> 내 상품 목록
+      </div>
 
-        {/* 컨텐츠 영역*/}
-        <div className="relative w-full px-4 sm:px-6 lg:px-10 py-4 isolate flex-1">
-          {/* 반응형 그리드 컨테이너 */}
-          <div 
-            className={`${getGridClasses()} isolate transform-gpu`}
-            style={{ minHeight: '280px' }} // 카드 높이에 맞춰 조정
-          >
-            {/* 로딩 상태 */}
-            {isLoading && (
-              <>
-                {Array.from({ length: itemsToShow }, (_, index) => (
-                  <SkeletonProductCard key={`skeleton-${index}`} />
-                ))}
-              </>
-            )}
+      {/* 컨텐츠 영역 */}
+      <div className="relative w-full px-4 sm:px-6 lg:px-10 py-4 isolate flex-1">
+        {/* 반응형 그리드 컨테이너 */}
+        <div 
+          className={`${gridClasses} isolate transform-gpu`}
+          style={{ minHeight: '280px' }}
+        >
+          {/* 로딩 상태 */}
+          {isLoading && (
+            Array.from({ length: itemsToShow }, (_, index) => (
+              <SkeletonProductCard key={`skeleton-${index}`} />
+            ))
+          )}
 
-            {/* 에러 상태 */}
-            {error && !isLoading && (
-              <ErrorState error={error} onRetry={actions.retry} />
-            )}
+          {/* 에러 상태 */}
+          {error && !isLoading && (
+            <ErrorState error={error} onRetry={actions.retry} />
+          )}
 
-            {/* 빈 상태 */}
-            {!isLoading && !error && myProducts.length === 0 && (
-              <EmptyState />
-            )}
+          {/* 빈 상태 */}
+          {!isLoading && !error && myProducts.length === 0 && (
+            <EmptyState />
+          )}
 
-            {/* 실제 상품 목록 */}
-            {!isLoading && !error && myProducts.length > 0 && (
-              <>
-                {visibleProducts.slice(0, itemsToShow).map((product, index) => (
-                  <div
-                    key={product.id}
-                    className="w-full max-w-[280px] flex justify-center isolate transform-gpu"
-                  >
-                    <ProductCard
-                      product={product}
-                      index={index}
-                      formatPrice={formatPrice}
-                    />
-                  </div>
-                ))}
-                
-                {/* 빈 슬롯 채우기 - 그리드 구조 유지 (모바일에서는 필요 없음) */}
-                {itemsToShow > 1 && visibleProducts.length < itemsToShow && (
-                  <>
-                    {Array.from({ length: itemsToShow - visibleProducts.length }, (_, index) => (
-                      <div key={`empty-${index}`} className="w-full max-w-[280px] hidden md:block"></div>
-                    ))}
-                  </>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* 네비게이션 버튼 */}
-          {!isLoading && !error && myProducts.length > itemsToShow && (
-            <div className="flex justify-between items-center mt-6">
-              {/* 이전 버튼 */}
-              <NavigationButton
-                direction="prev"
-                onClick={actions.goPrev}
-                disabled={!slideInfo.canGoPrev}
-              />
-
-              {/* 다음 버튼 */}
-              <NavigationButton
-                direction="next"
-                onClick={actions.goNext}
-                disabled={!slideInfo.canGoNext}
-              />
-            </div>
+          {/* 실제 상품 목록 - 최적화된 렌더링 */}
+          {!isLoading && !error && myProducts.length > 0 && (
+            <>
+              {visibleProducts.slice(0, itemsToShow).map((product, index) => (
+                <div
+                  key={product.id}
+                  className="w-full max-w-[280px] flex justify-center isolate transform-gpu"
+                >
+                  <ProductCard
+                    product={product}
+                    index={index}
+                    formatPrice={formatPrice}
+                    itemsToShow={itemsToShow}
+                  />
+                </div>
+              ))}
+              
+              {/* 빈 슬롯 채우기 - 데스크톱에서만 */}
+              {itemsToShow > 1 && visibleProducts.length < itemsToShow && (
+                Array.from({ length: itemsToShow - visibleProducts.length }, (_, index) => (
+                  <div key={`empty-${index}`} className="w-full max-w-[280px] hidden md:block"></div>
+                ))
+              )}
+            </>
           )}
         </div>
+
+        {/* 네비게이션 버튼 */}
+        {!isLoading && !error && myProducts.length > itemsToShow && (
+          <div className="flex justify-between items-center mt-6">
+            <NavigationButton
+              direction="prev"
+              onClick={actions.goPrev}
+              disabled={!slideInfo.canGoPrev}
+            />
+
+            <NavigationButton
+              direction="next"
+              onClick={actions.goNext}
+              disabled={!slideInfo.canGoNext}
+            />
+          </div>
+        )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useCallback, useState, useEffect, useMemo } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { useMySaleList } from "../model/model";
 import { ProductCard } from "./productCards";
 import { NavigationButton } from "./navButton";
 
-// 스켈레톤 카드 컴포넌트 - 단순화
+// 스켈레톤 카드 컴포넌트
 const SkeletonProductCard: React.FC = () => (
-  <div className="w-full max-w-[280px] flex justify-center isolate transform-gpu">
+  <div className="w-full max-w-[280px] flex justify-center">
     <div className="w-full h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm">
       {/* 이미지 영역 */}
       <div className="w-full h-[200px] sm:h-[180px] lg:h-[160px] bg-gray-200 rounded-t-lg animate-pulse"></div>
@@ -39,7 +39,10 @@ const EmptyState: React.FC = () => (
 );
 
 // 에러 상태 컴포넌트
-const ErrorState: React.FC<{ error: string; onRetry: () => void }> = ({ error, onRetry }) => (
+const ErrorState: React.FC<{ error: string; onRetry: () => void }> = ({
+  error,
+  onRetry
+}) => (
   <div className="col-span-full flex items-center justify-center min-h-[250px]">
     <div className="text-center">
       <div className="text-red-500 mb-3">{error}</div>
@@ -54,10 +57,17 @@ const ErrorState: React.FC<{ error: string; onRetry: () => void }> = ({ error, o
 );
 
 export default function MySaleList() {
-  const { myProducts, visibleProducts, slideInfo, isLoading, error, actions } = useMySaleList();
+  const {
+    myProducts,
+    visibleProducts,
+    slideInfo,
+    isLoading,
+    error,
+    actions
+  } = useMySaleList();
   const [itemsToShow, setItemsToShow] = useState(1);
 
-  // 반응형 설정 - 최적화
+  // 반응형 설정
   useEffect(() => {
     const updateItemsToShow = () => {
       const width = window.innerWidth;
@@ -93,13 +103,11 @@ export default function MySaleList() {
     return new Intl.NumberFormat("ko-KR").format(price) + "원";
   }, []);
 
-  // 반응형 그리드 클래스 - 메모이제이션
-  const gridClasses = useMemo(() => 
-    "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3", 
-  []);
+  // 반응형 그리드 클래스
+  const gridClasses = "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
 
   return (
-    <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden isolate transform-gpu">
+    <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden">
       {/* 헤더 */}
       <div className="custom-box2-title mb-4 flex-shrink-0">
         <span className="custom-box2-icon">🛒</span> 내 상품 목록
@@ -108,8 +116,8 @@ export default function MySaleList() {
       {/* 컨텐츠 영역 */}
       <div className="relative w-full px-4 sm:px-6 lg:px-10 py-4 isolate flex-1">
         {/* 반응형 그리드 컨테이너 */}
-        <div 
-          className={`${gridClasses} isolate transform-gpu`}
+        <div
+          className={gridClasses}
           style={{ minHeight: '280px' }}
         >
           {/* 로딩 상태 */}
@@ -135,13 +143,12 @@ export default function MySaleList() {
               {visibleProducts.slice(0, itemsToShow).map((product, index) => (
                 <div
                   key={product.id}
-                  className="w-full max-w-[280px] flex justify-center isolate transform-gpu"
+                  className="w-full max-w-[280px] flex justify-center"
                 >
                   <ProductCard
                     product={product}
                     index={index}
                     formatPrice={formatPrice}
-                    itemsToShow={itemsToShow}
                   />
                 </div>
               ))}

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -6,7 +6,7 @@ import { useMySaleList } from "../model/model";
 import { ProductCard } from "./productCards";
 import { NavigationButton } from "./navButton";
 
-// 스켈레톤 카드 컴포넌트 - 실제 ProductCard와 동일한 크기 보장
+// 스켈레톤 카드 컴포넌트
 const SkeletonProductCard: React.FC = () => (
   <div className="w-full max-w-[280px] flex justify-center isolate transform-gpu">
     <div className="w-full h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm animate-pulse">
@@ -88,9 +88,6 @@ export default function MySaleList() {
     return new Intl.NumberFormat("ko-KR").format(price) + "원";
   }, []);
 
-  // 첫 번째 상품 이미지만 preload (LCP 최적화)
-  const firstImage = visibleProducts[0]?.imageUrls?.[0];
-
   // 반응형 그리드 클래스 생성
   const getGridClasses = () => {
     return "grid gap-4 justify-items-center grid-cols-1 md:grid-cols-2 lg:grid-cols-3";
@@ -98,27 +95,16 @@ export default function MySaleList() {
 
   return (
     <>
-      {/* 첫 번째 이미지 preload */}
-      {firstImage && (
-        <Head>
-          <link
-            rel="preload"
-            as="image"
-            href={firstImage}
-            fetchPriority="high"
-          />
-        </Head>
-      )}
       
       <div className="custom-box2 shadow-lg flex flex-col w-full overflow-hidden isolate transform-gpu">
-        {/* 헤더 - 고정 높이 */}
+        {/* 헤더 */}
         <div className="custom-box2-title mb-4 flex-shrink-0">
           <span className="custom-box2-icon">🛒</span> 내 상품 목록
         </div>
 
-        {/* 컨텐츠 영역 - 최소 높이 보장으로 layout shift 방지 */}
+        {/* 컨텐츠 영역*/}
         <div className="relative w-full px-4 sm:px-6 lg:px-10 py-4 isolate flex-1">
-          {/* 반응형 그리드 컨테이너 - 고정 최소 높이 */}
+          {/* 반응형 그리드 컨테이너 */}
           <div 
             className={`${getGridClasses()} isolate transform-gpu`}
             style={{ minHeight: '280px' }} // 카드 높이에 맞춰 조정

--- a/src/features/mypage/mySaleList/ui/mySaleList.tsx
+++ b/src/features/mypage/mySaleList/ui/mySaleList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useCallback, useState, useEffect } from "react";
-import Head from "next/head";
 import { useMySaleList } from "../model/model";
 import { ProductCard } from "./productCards";
 import { NavigationButton } from "./navButton";

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -5,22 +5,19 @@ import { getBeeTypeKorean } from "@/shared/types/beeSwitch";
 import { useRouter } from "next/navigation";
 
 /**
- * LCP 최적화된 상품 카드 컴포넌트
+ * 상품 카드 컴포넌트
  */
 interface ProductCardProps {
   product: ProductWithBusiness;
   index: number;
   formatPrice: (price: number) => string;
-  itemsToShow: number; // 현재 화면에 표시되는 아이템 수
 }
 
 export const ProductCard = memo<ProductCardProps>(
-  ({ product, index, formatPrice, itemsToShow }) => {
+  ({ product, index, formatPrice }) => {
     const [imageError, setImageError] = useState(false);
     const router = useRouter();
 
-    // Above-the-fold 이미지 판단
-    const isAboveFold = index < itemsToShow;
     
     const handleImageError = useCallback(() => {
       setImageError(true);
@@ -37,40 +34,38 @@ export const ProductCard = memo<ProductCardProps>(
       }
     }, [handleCardClick]);
 
-    // 이미지 URL 최적화
+    // 이미지 URL
     const optimizedImageUrl = product.imageUrls?.[0];
 
     return (
-      <article 
-          className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
-          onClick={handleCardClick}
-          onKeyDown={handleKeyPress}
-          role="button"
-          tabIndex={0}
-          aria-label={`${product.name} 상품 상세보기`}
-        >
+      <article
+        className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto"
+        onClick={handleCardClick}
+        onKeyDown={handleKeyPress}
+        role="button"
+        tabIndex={0}
+        aria-label={`${product.name} 상품 상세보기`}
+      >
           {/* 상품 이미지 영역 */}
-          <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100 isolate transform-gpu">
+          <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100">
             {optimizedImageUrl && !imageError ? (
               <Image
                 src={optimizedImageUrl}
                 alt={`${product.name} 상품 이미지`}
-                width={280}
-                height={200}
-                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu w-full h-full"
-                priority={isAboveFold}
-                loading={isAboveFold ? "eager" : "lazy"}
-                fetchPriority={isAboveFold ? "high" : "auto"}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+                priority={index === 0}
+                loading={index === 0 ? "eager" : "lazy"}
+                fetchPriority={index === 0 ? "high" : "auto"}
                 onError={handleImageError}
-                sizes="280px"
-                placeholder="blur"
-                blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkbHB0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyJckliyjqTzSlT54b6bk+h0R//2Q=="
+                sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
+                placeholder="empty"
                 unoptimized={true}
-                quality={60}
+                quality={85}
               />
             ) : (
               // 이미지 없음 또는 에러 상태
-              <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-400 isolate">
+              <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-400">
                 <svg className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 002 2v12a2 2 0 002 2z" />
                 </svg>
@@ -80,10 +75,10 @@ export const ProductCard = memo<ProductCardProps>(
           </div>
 
           {/* 상품 정보 영역 */}
-          <div className="p-3 sm:p-4 h-[120px] sm:h-[120px] lg:h-[120px] flex flex-col justify-between isolate">
+          <div className="p-3 sm:p-4 h-[120px] sm:h-[120px] lg:h-[120px] flex flex-col justify-between">
             <div className="space-y-1 sm:space-y-2">
               {/* 상품명 */}
-              <h3 
+              <h3
                 className="text-sm sm:text-base font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-blue-600 transition-colors duration-200"
                 title={product.name}
               >

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -79,14 +79,16 @@ export const ProductCard = memo<ProductCardProps>(
               <Image
                 src={optimizedImageUrl}
                 alt={`${product.name} 상품 이미지`}
-                fill
-                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
+                width={280}
+                height={200}
+                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu w-full h-full"
                 priority={isAboveFold}
                 loading={isAboveFold ? "eager" : "lazy"}
                 fetchPriority={isAboveFold ? "high" : "auto"}
                 onError={handleImageError}
                 sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
                 placeholder="empty"
+                unoptimized={true}
                 quality={75}
               />
             ) : (

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, memo, useEffect, useRef } from "react";
+import React, { useState, useCallback, memo } from "react";
 import Image from "next/image";
 import Head from "next/head";
 import { ProductWithBusiness } from "@/features/search/model/model";
@@ -6,32 +6,25 @@ import { getBeeTypeKorean } from "@/shared/types/beeSwitch";
 import { useRouter } from "next/navigation";
 
 /**
- * 상품 카드 컴포넌트
- * @param product - 상품 정보
- * @param index - 상품 인덱스
- * @param formatPrice - 가격 포맷팅 함수
+ * LCP 최적화된 상품 카드 컴포넌트
  */
 interface ProductCardProps {
   product: ProductWithBusiness;
   index: number;
   formatPrice: (price: number) => string;
+  itemsToShow: number; // 현재 화면에 표시되는 아이템 수
 }
 
 export const ProductCard = memo<ProductCardProps>(
-  ({ product, index, formatPrice }) => {
+  ({ product, index, formatPrice, itemsToShow }) => {
     const [imageError, setImageError] = useState(false);
-    const [isImageLoading, setIsImageLoading] = useState(true);
-    const [shouldLoadImage, setShouldLoadImage] = useState(index === 0); // 첫 번째만 즉시 로드
-    const cardRef = useRef<HTMLElement>(null);
     const router = useRouter();
 
-    const handleImageLoad = useCallback(() => {
-      setIsImageLoading(false);
-    }, []);
-
+    // Above-the-fold 이미지 판단 (현재 화면에 보이는 아이템들)
+    const isAboveFold = index < itemsToShow;
+    
     const handleImageError = useCallback(() => {
       setImageError(true);
-      setIsImageLoading(false);
     }, []);
 
     const handleCardClick = useCallback(() => {
@@ -45,48 +38,24 @@ export const ProductCard = memo<ProductCardProps>(
       }
     }, [handleCardClick]);
 
-    // Intersection Observer로 뷰포트 진입 감지
-    useEffect(() => {
-      if (index === 0 || shouldLoadImage) return; // 첫 번째는 이미 로드됨
-
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              setShouldLoadImage(true);
-              observer.disconnect();
-            }
-          });
-        },
-        { 
-          rootMargin: '50px', // 50px 전에 미리 로드
-          threshold: 0.1 
-        }
-      );
-
-      if (cardRef.current) {
-        observer.observe(cardRef.current);
-      }
-
-      return () => observer.disconnect();
-    }, [index, shouldLoadImage]);
+    // 이미지 URL 최적화 (CloudFront 직접 사용)
+    const optimizedImageUrl = product.imageUrls?.[0];
 
     return (
       <>
-        {/* 첫 번째 상품 이미지만 preload */}
-        {index === 0 && product.imageUrls?.[0] && (
+        {/* Above-the-fold 이미지들에 대한 preload */}
+        {isAboveFold && optimizedImageUrl && (
           <Head>
             <link
               rel="preload"
               as="image"
-              href={`/_next/image?url=${encodeURIComponent(product.imageUrls[0])}&w=280&q=60`}
+              href={optimizedImageUrl}
               fetchPriority="high"
             />
           </Head>
         )}
         
         <article 
-          ref={cardRef}
           className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
           onClick={handleCardClick}
           onKeyDown={handleKeyPress}
@@ -94,78 +63,63 @@ export const ProductCard = memo<ProductCardProps>(
           tabIndex={0}
           aria-label={`${product.name} 상품 상세보기`}
         >
-        {/* 상품 이미지 영역 */}
-        <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100 isolate transform-gpu">
-          {/* 로딩 상태 */}
-          {isImageLoading && (
-            <div className="absolute inset-0 w-full h-full flex items-center justify-center bg-gray-100 isolate">
-              <div className="flex flex-col items-center space-y-2">
-                <div className="w-6 h-6 sm:w-8 sm:h-8 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
-                <span className="text-xs text-gray-500">로딩중...</span>
+          {/* 상품 이미지 영역 - layout shift 방지를 위한 고정 크기 */}
+          <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100 isolate transform-gpu">
+            {optimizedImageUrl && !imageError ? (
+              <Image
+                src={optimizedImageUrl}
+                alt={`${product.name} 상품 이미지`}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
+                priority={isAboveFold}
+                loading={isAboveFold ? "eager" : "lazy"}
+                fetchPriority={isAboveFold ? "high" : "auto"}
+                onError={handleImageError}
+                sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
+                placeholder="empty"
+                unoptimized={true}
+                quality={85}
+              />
+            ) : (
+              // 이미지 없음 또는 에러 상태
+              <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-400 isolate">
+                <svg className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 002 2v12a2 2 0 002 2z" />
+                </svg>
+                <span className="text-xs font-medium">이미지 없음</span>
+              </div>
+            )}
+          </div>
+
+          {/* 상품 정보 영역 */}
+          <div className="p-3 sm:p-4 h-[120px] sm:h-[120px] lg:h-[120px] flex flex-col justify-between isolate">
+            <div className="space-y-1 sm:space-y-2">
+              {/* 상품명 */}
+              <h3 
+                className="text-sm sm:text-base font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-blue-600 transition-colors duration-200"
+                title={product.name}
+              >
+                {product.name}
+              </h3>
+
+              {/* 가격 */}
+              <div className="text-base sm:text-lg font-bold text-blue-600">
+                {formatPrice(product.price)}
               </div>
             </div>
-          )}
 
-          {/* 이미지 영역 - layout shift 방지를 위한 고정 크기 */}
-          {shouldLoadImage && product.imageUrls && product.imageUrls.length > 0 && !imageError ? (
-            <Image
-              src={product.imageUrls[0]}
-              alt={`${product.name} 상품 이미지`}
-              fill
-              className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
-              priority={index === 0}
-              loading={index === 0 ? "eager" : "lazy"}
-              fetchPriority={index === 0 ? "high" : "auto"}
-              onLoad={handleImageLoad}
-              onError={handleImageError}
-              sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
-              placeholder="empty"
-              unoptimized={false}
-              quality={60}
-            />
-          ) : shouldLoadImage ? (
-            <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-400 isolate">
-              <svg className="w-8 h-8 sm:w-10 sm:h-10 lg:w-12 lg:h-12 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
-              <span className="text-xs font-medium">이미지 없음</span>
-            </div>
-          ) : (
-            <div className="absolute inset-0 w-full h-full flex items-center justify-center bg-gray-100 isolate">
-              <div className="w-8 h-8 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-            </div>
-        )}
-        </div>
-
-        {/* 상품 정보 영역 */}
-        <div className="p-3 sm:p-4 h-[120px] sm:h-[120px] lg:h-[120px] flex flex-col justify-between isolate">
-          <div className="space-y-1 sm:space-y-2">
-            {/* 상품명 */}
-            <h3 
-              className="text-sm sm:text-base font-semibold text-gray-900 whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-blue-600 transition-colors duration-200"
-              title={product.name}
-            >
-              {product.name}
-            </h3>
-
-            {/* 가격 */}
-            <div className="text-base sm:text-lg font-bold text-blue-600">
-              {formatPrice(product.price)}
+            {/* 추가 정보 */}
+            <div className="flex items-center justify-between text-xs sm:text-sm text-gray-500">
+              <div className="flex items-center space-x-1">
+                <span className="px-2 py-1 bg-gray-100 rounded-full text-xs font-medium truncate max-w-[80px] sm:max-w-[100px]">
+                  {getBeeTypeKorean(product.beeType)}
+                </span>
+              </div>
+              <div className="truncate max-w-[60px] sm:max-w-[80px]" title={product.origin}>
+                {product.origin}
+              </div>
             </div>
           </div>
-
-          {/* 추가 정보 */}
-          <div className="flex items-center justify-between text-xs sm:text-sm text-gray-500">
-            <div className="flex items-center space-x-1">
-              <span className="px-2 py-1 bg-gray-100 rounded-full text-xs font-medium truncate max-w-[80px] sm:max-w-[100px]">
-                {getBeeTypeKorean(product.beeType)}
-              </span>
-            </div>
-            <div className="truncate max-w-[60px] sm:max-w-[80px]" title={product.origin}>
-              {product.origin}
-            </div>
-          </div>
-        </div>
 
           {/* 호버 오버레이 */}
           <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -22,7 +22,7 @@ export const ProductCard = memo<ProductCardProps>(
     // Above-the-fold 이미지 판단 (현재 화면에 보이는 아이템들)
     const isAboveFold = index < itemsToShow;
     
-    // CloudFront 도메인 preconnect (최초 렌더링 시 한 번만)
+    // CloudFront 도메인 preconnect
     useEffect(() => {
       if (isAboveFold && index === 0) {
         const link = document.createElement('link');
@@ -61,8 +61,10 @@ export const ProductCard = memo<ProductCardProps>(
       }
     }, [handleCardClick]);
 
-    // 이미지 URL 최적화 (CloudFront 직접 사용)
-    const optimizedImageUrl = product.imageUrls?.[0];
+    // 이미지 URL 최적화
+    const optimizedImageUrl = product.imageUrls?.[0] 
+      ? `${product.imageUrls[0]}?w=280&h=200&q=60&f=webp`
+      : undefined;
 
     return (
       <article 

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, memo, useEffect, useRef } from "react";
 import Image from "next/image";
+import Head from "next/head";
 import { ProductWithBusiness } from "@/features/search/model/model";
 import { getBeeTypeKorean } from "@/shared/types/beeSwitch";
 import { useRouter } from "next/navigation";
@@ -71,15 +72,28 @@ export const ProductCard = memo<ProductCardProps>(
     }, [index, shouldLoadImage]);
 
     return (
-      <article 
-        ref={cardRef}
-        className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
-        onClick={handleCardClick}
-        onKeyDown={handleKeyPress}
-        role="button"
-        tabIndex={0}
-        aria-label={`${product.name} 상품 상세보기`}
-      >
+      <>
+        {/* 첫 번째 상품 이미지만 preload */}
+        {index === 0 && product.imageUrls?.[0] && (
+          <Head>
+            <link
+              rel="preload"
+              as="image"
+              href={`/_next/image?url=${encodeURIComponent(product.imageUrls[0])}&w=280&q=60`}
+              fetchPriority="high"
+            />
+          </Head>
+        )}
+        
+        <article 
+          ref={cardRef}
+          className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
+          onClick={handleCardClick}
+          onKeyDown={handleKeyPress}
+          role="button"
+          tabIndex={0}
+          aria-label={`${product.name} 상품 상세보기`}
+        >
         {/* 상품 이미지 영역 */}
         <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100 isolate transform-gpu">
           {/* 로딩 상태 */}
@@ -99,16 +113,15 @@ export const ProductCard = memo<ProductCardProps>(
               alt={`${product.name} 상품 이미지`}
               fill
               className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
-              priority={index === 0} // 첫 번째 상품만 최우선 처리
+              priority={index === 0}
               loading={index === 0 ? "eager" : "lazy"}
               fetchPriority={index === 0 ? "high" : "auto"}
               onLoad={handleImageLoad}
               onError={handleImageError}
               sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
-              placeholder="blur"
-              blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCg"
+              placeholder="empty"
               unoptimized={false}
-              quality={75}
+              quality={60}
             />
           ) : shouldLoadImage ? (
             <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-gray-50 text-gray-400 isolate">
@@ -154,9 +167,10 @@ export const ProductCard = memo<ProductCardProps>(
           </div>
         </div>
 
-        {/* 호버 오버레이 */}
-        <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
-      </article>
+          {/* 호버 오버레이 */}
+          <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
+        </article>
+      </>
     );
   }
 );

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, memo, useEffect } from "react";
+import React, { useState, useCallback, memo } from "react";
 import Image from "next/image";
+import Head from "next/head";
 import { ProductWithBusiness } from "@/features/search/model/model";
 import { getBeeTypeKorean } from "@/shared/types/beeSwitch";
 import { useRouter } from "next/navigation";
@@ -19,32 +20,8 @@ export const ProductCard = memo<ProductCardProps>(
     const [imageError, setImageError] = useState(false);
     const router = useRouter();
 
-    // Above-the-fold 이미지 판단 (현재 화면에 보이는 아이템들)
+    // Above-the-fold 이미지 판단
     const isAboveFold = index < itemsToShow;
-    
-    // CloudFront 도메인 preconnect
-    useEffect(() => {
-      if (isAboveFold && index === 0) {
-        const link = document.createElement('link');
-        link.rel = 'preconnect';
-        link.href = 'https://d96w70pr33mqi.cloudfront.net';
-        link.crossOrigin = 'anonymous';
-        document.head.appendChild(link);
-        
-        const dnsLink = document.createElement('link');
-        dnsLink.rel = 'dns-prefetch';
-        dnsLink.href = 'https://d96w70pr33mqi.cloudfront.net';
-        document.head.appendChild(dnsLink);
-      }
-    }, [isAboveFold, index]);
-    
-    // 첫 번째 이미지 preload
-    useEffect(() => {
-      if (isAboveFold && product.imageUrls?.[0]) {
-        const img = new window.Image();
-        img.src = product.imageUrls[0];
-      }
-    }, [isAboveFold, product.imageUrls]);
     
     const handleImageError = useCallback(() => {
       setImageError(true);
@@ -62,12 +39,23 @@ export const ProductCard = memo<ProductCardProps>(
     }, [handleCardClick]);
 
     // 이미지 URL 최적화
-    const optimizedImageUrl = product.imageUrls?.[0] 
-      ? `${product.imageUrls[0]}?w=280&h=200&q=60&f=webp`
-      : undefined;
+    const optimizedImageUrl = product.imageUrls?.[0];
 
     return (
-      <article 
+      <>
+        {/* Above-the-fold 이미지들에 대한 preload */}
+        {isAboveFold && optimizedImageUrl && (
+          <Head>
+            <link
+              rel="preload"
+              as="image"
+              href={optimizedImageUrl}
+              fetchPriority="high"
+            />
+          </Head>
+        )}
+        
+        <article 
           className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
           onClick={handleCardClick}
           onKeyDown={handleKeyPress}
@@ -75,15 +63,14 @@ export const ProductCard = memo<ProductCardProps>(
           tabIndex={0}
           aria-label={`${product.name} 상품 상세보기`}
         >
-          {/* 상품 이미지 영역 - layout shift 방지를 위한 고정 크기 */}
+          {/* 상품 이미지 영역 */}
           <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100 isolate transform-gpu">
             {optimizedImageUrl && !imageError ? (
               <Image
                 src={optimizedImageUrl}
                 alt={`${product.name} 상품 이미지`}
-                width={280}
-                height={200}
-                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu w-full h-full"
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
                 priority={isAboveFold}
                 loading={isAboveFold ? "eager" : "lazy"}
                 fetchPriority={isAboveFold ? "high" : "auto"}
@@ -91,7 +78,7 @@ export const ProductCard = memo<ProductCardProps>(
                 sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
                 placeholder="empty"
                 unoptimized={true}
-                quality={75}
+                quality={85}
               />
             ) : (
               // 이미지 없음 또는 에러 상태
@@ -137,6 +124,7 @@ export const ProductCard = memo<ProductCardProps>(
           {/* 호버 오버레이 */}
           <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
         </article>
+      </>
     );
   }
 );

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, memo } from "react";
 import Image from "next/image";
-import Head from "next/head";
 import { ProductWithBusiness } from "@/features/search/model/model";
 import { getBeeTypeKorean } from "@/shared/types/beeSwitch";
 import { useRouter } from "next/navigation";
@@ -42,20 +41,7 @@ export const ProductCard = memo<ProductCardProps>(
     const optimizedImageUrl = product.imageUrls?.[0];
 
     return (
-      <>
-        {/* Above-the-fold 이미지들에 대한 preload */}
-        {isAboveFold && optimizedImageUrl && (
-          <Head>
-            <link
-              rel="preload"
-              as="image"
-              href={optimizedImageUrl}
-              fetchPriority="high"
-            />
-          </Head>
-        )}
-        
-        <article 
+      <article 
           className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto isolate transform-gpu will-change-transform"
           onClick={handleCardClick}
           onKeyDown={handleKeyPress}
@@ -69,16 +55,18 @@ export const ProductCard = memo<ProductCardProps>(
               <Image
                 src={optimizedImageUrl}
                 alt={`${product.name} 상품 이미지`}
-                fill
-                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu"
+                width={280}
+                height={200}
+                className="object-cover transition-transform duration-300 group-hover:scale-105 transform-gpu w-full h-full"
                 priority={isAboveFold}
                 loading={isAboveFold ? "eager" : "lazy"}
                 fetchPriority={isAboveFold ? "high" : "auto"}
                 onError={handleImageError}
-                sizes="(max-width: 640px) 280px, (max-width: 768px) 280px, (max-width: 1024px) 280px, 280px"
-                placeholder="empty"
+                sizes="280px"
+                placeholder="blur"
+                blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAhEAACAQMDBQAAAAAAAAAAAAABAgMABAUGIWGRkbHB0f/EABUBAQEAAAAAAAAAAAAAAAAAAAMF/8QAGhEAAgIDAAAAAAAAAAAAAAAAAAECEgMRkf/aAAwDAQACEQMRAD8AltJagyeH0AthI5xdrLcNM91BF5pX2HaH9bcfaSXWGaRmknyJckliyjqTzSlT54b6bk+h0R//2Q=="
                 unoptimized={true}
-                quality={85}
+                quality={60}
               />
             ) : (
               // 이미지 없음 또는 에러 상태
@@ -124,7 +112,6 @@ export const ProductCard = memo<ProductCardProps>(
           {/* 호버 오버레이 */}
           <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
         </article>
-      </>
     );
   }
 );

--- a/src/features/mypage/mySaleList/ui/productCards.tsx
+++ b/src/features/mypage/mySaleList/ui/productCards.tsx
@@ -38,14 +38,13 @@ export const ProductCard = memo<ProductCardProps>(
     const optimizedImageUrl = product.imageUrls?.[0];
 
     return (
-      <article
-        className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out cursor-pointer focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 mx-auto"
-        onClick={handleCardClick}
-        onKeyDown={handleKeyPress}
-        role="button"
-        tabIndex={0}
-        aria-label={`${product.name} 상품 상세보기`}
-      >
+      <article className="group relative w-full max-w-[280px] h-[320px] sm:h-[300px] lg:h-[280px] bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-lg transition-all duration-300 ease-in-out mx-auto">
+        <button
+          className="w-full h-full cursor-pointer focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-lg bg-transparent border-none p-0 text-left"
+          onClick={handleCardClick}
+          onKeyDown={handleKeyPress}
+          aria-label={`${product.name} 상품 상세보기`}
+        >
           {/* 상품 이미지 영역 */}
           <div className="relative w-full h-[200px] sm:h-[180px] lg:h-[160px] min-h-[160px] overflow-hidden rounded-t-lg bg-gray-100">
             {optimizedImageUrl && !imageError ? (
@@ -94,7 +93,7 @@ export const ProductCard = memo<ProductCardProps>(
             {/* 추가 정보 */}
             <div className="flex items-center justify-between text-xs sm:text-sm text-gray-500">
               <div className="flex items-center space-x-1">
-                <span className="px-2 py-1 bg-gray-100 rounded-full text-xs font-medium truncate max-w-[80px] sm:max-w-[100px]">
+                <span className="px-2 py-1 bg-gray-200 text-gray-800 rounded-full text-xs font-medium truncate max-w-[80px] sm:max-w-[100px]">
                   {getBeeTypeKorean(product.beeType)}
                 </span>
               </div>
@@ -106,7 +105,8 @@ export const ProductCard = memo<ProductCardProps>(
 
           {/* 호버 오버레이 */}
           <div className="absolute inset-0 bg-blue-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
-        </article>
+        </button>
+      </article>
     );
   }
 );

--- a/src/features/mypage/storeRecommendBee/ui/List.tsx
+++ b/src/features/mypage/storeRecommendBee/ui/List.tsx
@@ -68,7 +68,7 @@ const RecommendationCard: React.FC<{
       <span className="text-lg font-bold text-gray-800 truncate">
         {getBeeTypeKorean(item.beeType)}
       </span>
-      <span className="bg-pink-400 text-white text-xs px-2 py-1 rounded-full whitespace-nowrap">
+      <span className="bg-pink-500 text-white text-xs px-2 py-1 rounded-full whitespace-nowrap">
         추천
       </span>
     </div>
@@ -95,10 +95,10 @@ const RecommendationCard: React.FC<{
 
       {/* 태그 영역 - 고정 위치 */}
       <div className="flex flex-wrap gap-2 mt-2">
-        <span className="bg-gray-100 px-3 py-1 rounded-full text-xs truncate max-w-[80px]">
+        <span className="bg-gray-200 text-gray-800 px-3 py-1 rounded-full text-xs truncate max-w-[80px]">
           {getCultivationTypeKorean(item.cultivationType)}
         </span>
-        <span className="bg-gray-100 px-3 py-1 rounded-full text-xs truncate max-w-[100px]">
+        <span className="bg-gray-200 text-gray-800 px-3 py-1 rounded-full text-xs truncate max-w-[100px]">
           {item.cultivationAddress}
         </span>
       </div>

--- a/src/features/recommendBee/model/useRecommendation.ts
+++ b/src/features/recommendBee/model/useRecommendation.ts
@@ -56,10 +56,8 @@ export const useRecommendBee = create<RecommendBeeState>((set) => ({
       const response = await postRecommendation(formData);
       if (response?.data) {
         set({ resultData: response.data, isSuccess: true });
-        console.log("수정벌 추천 성공:", response.data);
       }
     } catch (error) {
-      console.log("수정벌 추천 실패:", error);
       set({ error: "수정벌 추천에 실패했습니다." });
     } finally {
       set({ loading: false });

--- a/src/features/recommendBee/model/useRecommendation.ts
+++ b/src/features/recommendBee/model/useRecommendation.ts
@@ -58,6 +58,7 @@ export const useRecommendBee = create<RecommendBeeState>((set) => ({
         set({ resultData: response.data, isSuccess: true });
       }
     } catch (error) {
+      console.error(error);
       set({ error: "수정벌 추천에 실패했습니다." });
     } finally {
       set({ loading: false });

--- a/src/features/recommendBee/model/useSaveRecommendation.ts
+++ b/src/features/recommendBee/model/useSaveRecommendation.ts
@@ -52,6 +52,7 @@ export const useSaveRecommendation = (
       const response = await saveRecommendation(mappedData);
       setIsSave(response);
     } catch (error) {
+      console.error(error);
     }
   };
 

--- a/src/features/recommendBee/model/useSaveRecommendation.ts
+++ b/src/features/recommendBee/model/useSaveRecommendation.ts
@@ -51,9 +51,7 @@ export const useSaveRecommendation = (
       );
       const response = await saveRecommendation(mappedData);
       setIsSave(response);
-      console.log("저장 직전 데이터:", mappedData);
     } catch (error) {
-      console.log("수정벌 추천 실패", error);
     }
   };
 

--- a/src/features/reviews/ui/ReviewsForm.tsx
+++ b/src/features/reviews/ui/ReviewsForm.tsx
@@ -25,7 +25,6 @@ export default function ReviewForm({
       setSubmitting(true);
       
       const response = await createReview(productId, content.trim());
-      console.log('리뷰 작성 성공:', response);
       
       // 새로운 리뷰 객체 생성
       const newReview: Review = {

--- a/src/shared/business/model.ts
+++ b/src/shared/business/model.ts
@@ -46,7 +46,6 @@ export const useBusinessStore = create<BusinessStore>((set, get) => ({
         },
         selectedDetail: data,
       }));
-      console.log("업체 상세조회 성공:", data);
     } catch (error) {
       console.error("업체 상세 조회 실패:", error);
     }


### PR DESCRIPTION
## 📌perf: Mypage 성능 개선
- Layout Shift 방지 해결
  - 모든 상태에서 min-height 고정으로 Layout Shift 사전 방지
  - 스켈레톤 UI와 실제 카드 UI의 크기 일치시켜서 로딩 완료 시에도 크기 변화 없도록 함
  - 제목 영역 높이 유지
  - 이미지 컨테이너 고정
  - 그리드 구조 안정화
 ### Layout Shift Score 0.184 → 0.01 (94.6%) 개선 달성
 ### 페이지 로딩 중에도 레이아웃 요소들이 움직이지 않아 사용자 경험 향상

## 📌perf: Mypage 웹 접근성 개선
- 상품 등록 버튼 및 수정벌 추천 div 색상 변경

## 📌refactor: 코드베이스 정리
- 사용하지 않는 의존성 제거 (class-variance-authority, react-router-dom 등)
- App Router에서 잘못된 next/head 사용 수정
- 사용하지 않는 CSS 클래스 제거
- production용 console.log 제거


### ⚠️LCP 성능 개선을 위해 여러 시도를 했으나 CloudFront에서 직접 개선해야 한다는 결론을 내리고 코드 롤백
 - Mypage 성능 45 → 80~85 개선